### PR TITLE
Accept tokens from the Logplex URL only

### DIFF
--- a/grind_test.go
+++ b/grind_test.go
@@ -36,7 +36,7 @@ func (n *NoopTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 var BogusLogplexUrl url.URL
 
 func init() {
-	url, err := url.Parse("https://locahost:23456")
+	url, err := url.Parse("https://token:a-token@locahost:23456")
 	if err != nil {
 		log.Fatalf("Could not parse url: %v", err)
 	}
@@ -55,7 +55,6 @@ func BenchmarkStartup(b *testing.B) {
 		RequestSizeTrigger: 100,
 		Concurrency:        3,
 		Period:             3 * time.Second,
-		Token:              "a-token",
 	}
 
 	for i := 0; i < b.N; i += 1 {
@@ -135,7 +134,6 @@ func NewNoopClient(f interface {
 		RequestSizeTrigger: sizeTrigger,
 		Concurrency:        3,
 		Period:             3 * time.Second,
-		Token:              "a-token",
 	}
 
 	c, err := NewClient(&cfg)
@@ -163,31 +161,19 @@ func BenchmarkFanInOut(b *testing.B) {
 }
 
 // Try logging to a real, live endpoint URL and token, specified by
-// LOGPLEX_URL and LOGPLEX_TOKEN.
+// LOGPLEX_URL.
 //
 // This is deceptively fast because dropping will be very common, even
 // on localhost.
 func BenchmarkToUrl(b *testing.B) {
 	b.StopTimer()
 
-	if os.Getenv("LOGPLEX_URL") == "" ||
-		os.Getenv("LOGPLEX_TOKEN") == "" {
-		b.Fatal("Skipping, no LOGPLEX_URL and LOGPLEX_TOKEN " +
-			"environment variable set")
+	if os.Getenv("LOGPLEX_URL") == "" {
+		b.Fatal("Skipping, no LOGPLEX_URL environment variable set")
 		return
 	}
 
 	logplexUrl, err := url.Parse(os.Getenv("LOGPLEX_URL"))
-	if err != nil {
-		b.Fatalf("Could not parse logplex endpoint %q: %v",
-			os.Getenv("LOGPLEX_URL"), err)
-	}
-
-	token := os.Getenv("LOGPLEX_TOKEN")
-	if token == "" {
-		b.Fatalf("Invalid LOGPLEX_TOKEN set: %q", token)
-	}
-
 	if err != nil {
 		b.Fatalf("Could not parse logplex endpoint %q: %v",
 			os.Getenv("LOGPLEX_URL"), err)
@@ -206,7 +192,6 @@ func BenchmarkToUrl(b *testing.B) {
 		RequestSizeTrigger: 100 * KB,
 		Concurrency:        3,
 		Period:             3 * time.Second,
-		Token:              token,
 	}
 
 	c, err := NewClient(&cfg)

--- a/logplexc.go
+++ b/logplexc.go
@@ -81,7 +81,6 @@ type Client struct {
 
 type Config struct {
 	Logplex            url.URL
-	Token              string
 	HttpClient         http.Client
 	RequestSizeTrigger int
 	Concurrency        int
@@ -96,7 +95,6 @@ func NewClient(cfg *Config) (*Client, error) {
 	c, err := NewMiniClient(
 		&MiniConfig{
 			Logplex:    cfg.Logplex,
-			Token:      cfg.Token,
 			HttpClient: cfg.HttpClient,
 		})
 

--- a/minimal.go
+++ b/minimal.go
@@ -2,6 +2,7 @@ package logplexc
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,7 +26,6 @@ type MiniStats struct {
 // constructing a client instance.
 type MiniConfig struct {
 	Logplex    url.URL
-	Token      string
 	HttpClient http.Client
 }
 
@@ -46,6 +46,9 @@ type MiniClient struct {
 	// Configuration that should not be mutated after creation
 	MiniConfig
 
+	// Cached copy of the token, extracted from the Logplex URL.
+	token string
+
 	reqInFlight sync.WaitGroup
 
 	// Messages that have been collected but not yet sent.
@@ -61,11 +64,16 @@ func NewMiniClient(cfg *MiniConfig) (client *MiniClient, err error) {
 	// Make a private copy
 	c.MiniConfig = *cfg
 
-	// If the username and password weren't part of the URL, use
-	// the logplex-token as the password
-	if c.Logplex.User == nil {
-		c.Logplex.User = url.UserPassword("token", c.Token)
+	if c.MiniConfig.Logplex.User == nil {
+		return nil, errors.New("No logplex user information provided")
 	}
+
+	token, ok := c.MiniConfig.Logplex.User.Password()
+	if !ok {
+		return nil, errors.New("No logplex password provided")
+	}
+
+	c.token = token
 
 	return &c, nil
 }
@@ -100,7 +108,7 @@ func (c *MiniClient) BufferMessage(
 	when time.Time, host string, procId string, log []byte) MiniStats {
 	ts := when.UTC().Format(time.RFC3339)
 	syslogPrefix := "<134>1 " + ts + " " + host + " " +
-		c.Token + " " + procId + " - - "
+		c.token + " " + procId + " - - "
 	msgLen := len(syslogPrefix) + len(log)
 
 	// Avoid racing against other operations that may want to swap


### PR DESCRIPTION
Logplex is switching preferred convention to reason about a monolithic
URL rather than a URL and a token.  Simplify configuration by removing
the separate token configuration.
